### PR TITLE
Handle JSON-LD articleBody to avoid truncated articles

### DIFF
--- a/src/articleExtractor.js
+++ b/src/articleExtractor.js
@@ -2,6 +2,26 @@ const { Readability } = require('@mozilla/readability');
 const { JSDOM } = require('jsdom');
 const axios = require('axios');
 
+function extractFromLdJson(doc) {
+  const scripts = doc.querySelectorAll('script[type="application/ld+json"]');
+  for (const script of scripts) {
+    try {
+      const data = JSON.parse(script.textContent.trim());
+      const candidates = Array.isArray(data)
+        ? data
+        : (Array.isArray(data['@graph']) ? data['@graph'] : [data]);
+      for (const item of candidates) {
+        if (item && item.articleBody) {
+          return item;
+        }
+      }
+    } catch (e) {
+      // Skip invalid JSON
+    }
+  }
+  return null;
+}
+
 async function extractArticle(url) {
   try {
     console.log(`Fetching article from: ${url}`);
@@ -18,7 +38,31 @@ async function extractArticle(url) {
     const dom = new JSDOM(response.data, { url });
     const doc = dom.window.document;
 
-    // Extract with Readability
+    // Prefer JSON-LD articleBody if available to avoid truncated content
+    const ld = extractFromLdJson(doc);
+    if (ld && ld.articleBody) {
+      const paragraphs = ld.articleBody
+        .split(/\n{2,}/)
+        .map(p => p.trim())
+        .filter(Boolean)
+        .map(p => `<p>${p}</p>`)
+        .join('\n');
+
+      return {
+        title: ld.headline || extractTitleFromUrl(url),
+        content: paragraphs,
+        textContent: ld.articleBody,
+        length: ld.articleBody.length,
+        excerpt: ld.description || ld.articleBody.substring(0, 300) + '...',
+        byline: Array.isArray(ld.author) ? ld.author[0]?.name : ld.author?.name || 'Unknown',
+        siteName: ld.publisher?.name || extractSiteFromUrl(url),
+        url: url,
+        publishedTime: ld.datePublished || extractPublishedTime(doc) || new Date().toISOString(),
+        lang: ld.inLanguage || 'en'
+      };
+    }
+
+    // Fallback to Readability
     const reader = new Readability(doc);
     const article = reader.parse();
 


### PR DESCRIPTION
## Summary
- parse `application/ld+json` data to detect full article text
- prefer JSON-LD articleBody before Readability to avoid truncated content
- Background: 
  - Diagnosed that production EPUB generation only captured the first section of multi‑part articles like the Baldwin piece because the page loads later sections via JavaScript, leaving Readability with partial content.
  - Added a JSON‑LD parser that extracts the full articleBody when available, assembling it into paragraph markup before falling back to Readability

## Testing
- `node test-extraction.js`
- `node test-extraction-with-fivefilters.js`
- `node test-epub-generation.js`


------
https://chatgpt.com/codex/tasks/task_e_689e9986e890832e995ffb62f399581f



----



