### PR TITLE
Prefer longest JSON-LD article body

### DIFF
--- a/src/articleExtractor.js
+++ b/src/articleExtractor.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 
 function extractFromLdJson(doc) {
   const scripts = doc.querySelectorAll('script[type="application/ld+json"]');
+  let best = null;
   for (const script of scripts) {
     try {
       const data = JSON.parse(script.textContent.trim());
@@ -12,14 +13,16 @@ function extractFromLdJson(doc) {
         : (Array.isArray(data['@graph']) ? data['@graph'] : [data]);
       for (const item of candidates) {
         if (item && item.articleBody) {
-          return item;
+          if (!best || item.articleBody.length > best.articleBody.length) {
+            best = item;
+          }
         }
       }
     } catch (e) {
       // Skip invalid JSON
     }
   }
-  return null;
+  return best;
 }
 
 async function extractArticle(url) {


### PR DESCRIPTION
## Summary
- choose the longest available `articleBody` from JSON-LD blocks to avoid truncated extractions

## Testing
- `npm test`
- `node test-extraction.js`
- `node test-epub-generation.js`


------
https://chatgpt.com/codex/tasks/task_e_689e9e590ac8832eb70711f71ff7187d