### PR TITLE
fix: correct backup schedule syntax

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,8 @@ on:
     branches: [ main ]
   release:
     types: [ published ]
+  schedule:
+    - cron: '0 2 * * *'
 
 env:
   REGISTRY: ghcr.io
@@ -35,7 +37,7 @@ jobs:
       run: npx --yes nyc --reporter=lcov npm test
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage/lcov.info
         flags: unittests
@@ -240,8 +242,6 @@ jobs:
   backup:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    schedule:
-      - cron: '0 2 * * *'  # Daily at 2 AM UTC
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- fix CI backup job syntax by moving scheduled cron trigger to workflow trigger section
- update Codecov action to v4 to run on supported Node version

## Testing
- `actionlint .github/workflows/ci-cd.yml`
- `npm test`
- `npm run lint` *(fails: trailing spaces in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_689f316b9c20832ebe02a0ae3e6cd9d9