### PR TITLE
Include commit hash in EPUB filenames

### DIFF
--- a/src/epubGenerator.js
+++ b/src/epubGenerator.js
@@ -1,6 +1,7 @@
 const Epub = require('epub-gen');
 const path = require('path');
 const fs = require('fs').promises;
+const { execSync } = require('child_process');
 
 async function generateEpub(article) {
   try {
@@ -37,7 +38,14 @@ async function generateEpub(article) {
     // Pass diagnostics through to the EPUB content
     article.extractionDiagnostics = extractionDiagnostics;
     
-    const filename = `${sanitizeFilename(article.title)}.epub`;
+    let commitHash = 'unknown';
+    try {
+      commitHash = execSync('git rev-parse --short HEAD').toString().trim();
+    } catch (e) {
+      console.warn('Could not determine git commit hash:', e.message);
+    }
+
+    const filename = `${sanitizeFilename(article.title)}_${commitHash}.epub`;
     const outputPath = path.join('/tmp', filename);
     
     console.log('EPUB Generation - Filename:', filename);

--- a/test-epub-generation.js
+++ b/test-epub-generation.js
@@ -10,6 +10,7 @@ const path = require('path');
 const { JSDOM } = require('jsdom');
 const AdmZip = require('adm-zip');
 const { generateEpub } = require('./src/epubGenerator');
+const { execSync } = require('child_process');
 
 // Test that EPUB contains expected content
 async function testEpubGeneration() {
@@ -78,6 +79,14 @@ async function testEpubGeneration() {
     const epubResult = await generateEpub(epubArticle);
     console.log(`✅ EPUB generated: ${epubResult.filename}`);
     console.log(`📦 EPUB size: ${(epubResult.size / 1024).toFixed(2)} KB`);
+
+    const commitHash = execSync('git rev-parse --short HEAD').toString().trim();
+    if (epubResult.filename.includes(commitHash)) {
+      console.log(`📝 Filename contains commit hash: ${commitHash}`);
+    } else {
+      console.log(`❌ Filename missing commit hash ${commitHash}`);
+      return false;
+    }
     
     // Step 3: Verify EPUB contents
     console.log('\n🔍 Step 3: Verifying EPUB contents...');


### PR DESCRIPTION
## Summary
- append current git commit hash to generated EPUB filenames
- add test ensuring EPUB filenames include commit hash

## Testing
- `npm test`
- `node test-epub-generation.js`


------
https://chatgpt.com/codex/tasks/task_e_68a11ecdec78832ebb0d7f463465002e