### PR TITLE
Add parse issue reporting form with GitHub issue creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agents Guide
+
+This project uses GitHub Issues and Codex automations to triage article extraction problems. For local development, note that the CLI environment already has:
+
+- `gh` (GitHub CLI) for interacting with repositories and issues
+- `doctl` (DigitalOcean CLI) for managing infrastructure
+
+Feel free to leverage these tools in scripts or manual workflows when handling article triage and deployment tasks.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ ZOTERO_USER_ID=your-numeric-user-id
 ZOTERO_API_KEY=your-api-key
 ZOTERO_TEST_COLLECTION=optional-collection-key
 
+# Optional automation
+CODEX_AGENT_API_URL=https://codex.example.com/v1/jobs
+CODEX_AGENT_API_KEY=your-secret
+CODEX_AGENT_ID=parse-triage
+
 ```
 
 ### 3. Setup Kindle
@@ -120,3 +125,6 @@ The bookmarklet runs Mozilla Readability.js in your browser to extract clean art
 - Test Zotero API key permissions
 - Check browser console for bookmarklet errors
 
+## Automated Codex Triage (Optional)
+
+If `CODEX_AGENT_API_URL` is configured, every failed extraction report will trigger a POST request to your Codex automation service containing the GitHub issue number, repository name, reporter notes, and the server's Readability analysis. Use this hook to launch an agent that can reproduce the problem, diagnose it, and open a pull request. Provide `CODEX_AGENT_API_KEY` if the endpoint requires authentication, and optionally `CODEX_AGENT_ID` to select a specific agent profile.

--- a/public/index.html
+++ b/public/index.html
@@ -112,6 +112,134 @@
             margin-right: 10px;
             font-weight: bold;
         }
+
+        .report-form {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            margin-top: 15px;
+        }
+
+        .report-form label {
+            font-weight: 600;
+        }
+
+        .report-form input[type="url"],
+        .report-form textarea {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ced4da;
+            border-radius: 6px;
+            font-size: 14px;
+            box-sizing: border-box;
+        }
+
+        .report-form textarea {
+            min-height: 100px;
+            resize: vertical;
+        }
+
+        .report-form button {
+            align-self: flex-start;
+            background: #2ecc71;
+            color: white;
+            border: none;
+            padding: 10px 16px;
+            border-radius: 6px;
+            font-size: 14px;
+            cursor: pointer;
+        }
+
+        .report-form button:hover {
+            background: #27ae60;
+        }
+
+        .report-status {
+            margin-top: 10px;
+            font-size: 0.95em;
+            display: none;
+        }
+
+        .report-status.success {
+            color: #155724;
+        }
+
+        .report-status.error {
+            color: #721c24;
+        }
+
+        .report-status.pending {
+            color: #856404;
+        }
+
+        .help-text {
+            font-size: 0.85em;
+            color: #6c757d;
+            margin-top: -6px;
+            margin-bottom: 4px;
+        }
+
+        .inline-feedback {
+            display: none;
+            font-size: 0.85em;
+            color: #e74c3c;
+        }
+
+        .inline-feedback.visible {
+            display: block;
+        }
+
+        .screenshot-preview {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        .screenshot-card {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px;
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            background: white;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+            max-width: 240px;
+        }
+
+        .screenshot-thumb {
+            width: 64px;
+            height: 64px;
+            object-fit: cover;
+            border-radius: 4px;
+            border: 1px solid #ced4da;
+        }
+
+        .screenshot-info {
+            flex: 1;
+        }
+
+        .screenshot-name {
+            font-size: 0.9em;
+            font-weight: 600;
+            margin-bottom: 2px;
+            word-break: break-word;
+        }
+
+        .screenshot-meta {
+            font-size: 0.8em;
+            color: #6c757d;
+        }
+
+        .screenshot-remove {
+            background: none;
+            border: none;
+            color: #e74c3c;
+            cursor: pointer;
+            font-size: 0.8em;
+            padding: 0;
+            margin-top: 6px;
+        }
     </style>
 </head>
 <body>
@@ -222,6 +350,27 @@ ZOTERO_TEST_COLLECTION=collection-key-optional
         </ul>
     </div>
 
+    <div class="section">
+        <h2>🚨 Report Extraction Problem</h2>
+        <p>If an article doesn't parse correctly, send the URL so we can investigate.</p>
+        <form id="failure-report-form" class="report-form">
+            <label for="failure-url">Problem URL</label>
+            <input type="url" id="failure-url" name="failure-url" placeholder="https://example.com/article" required>
+
+            <label for="failure-notes">Details (optional)</label>
+            <textarea id="failure-notes" name="failure-notes" placeholder="Add notes that might help reproduce the problem"></textarea>
+
+            <label for="failure-screenshot">Screenshots (optional)</label>
+            <input type="file" id="failure-screenshot" accept="image/*" multiple>
+            <p class="help-text">Paste screenshots with ⌘V / Ctrl+V or upload images (max 3, 2MB each).</p>
+            <div id="failure-screenshot-feedback" class="inline-feedback"></div>
+            <div id="failure-screenshot-list" class="screenshot-preview"></div>
+
+            <button type="submit">Submit Report</button>
+        </form>
+        <div id="failure-report-status" class="report-status"></div>
+    </div>
+
     <script>
         // Generate bookmarklet code
         function generateBookmarklet() {
@@ -310,11 +459,293 @@ ZOTERO_TEST_COLLECTION=collection-key-optional
             textarea.setSelectionRange(0, 0);
             textarea.blur();
         }
-        
+
+        function initFailureReportForm() {
+            const form = document.getElementById('failure-report-form');
+            if (!form) return;
+
+            const statusEl = document.getElementById('failure-report-status');
+            const notesInput = document.getElementById('failure-notes');
+            const screenshotInput = document.getElementById('failure-screenshot');
+            const attachmentsList = document.getElementById('failure-screenshot-list');
+            const attachmentsFeedback = document.getElementById('failure-screenshot-feedback');
+
+            const attachments = [];
+            const MAX_SCREENSHOTS = 3;
+            const MAX_SCREENSHOT_BYTES = 2 * 1024 * 1024; // 2MB
+
+            function formatBytes(bytes) {
+                if (!bytes || Number.isNaN(bytes)) return '0 KB';
+                const kilobytes = Math.max(1, Math.round(bytes / 1024));
+                return `${kilobytes.toLocaleString()} KB`;
+            }
+
+            function showAttachmentFeedback(message) {
+                if (!attachmentsFeedback) return;
+                attachmentsFeedback.textContent = message;
+                attachmentsFeedback.classList.add('visible');
+            }
+
+            function clearAttachmentFeedback() {
+                if (!attachmentsFeedback) return;
+                attachmentsFeedback.textContent = '';
+                attachmentsFeedback.classList.remove('visible');
+            }
+
+            function renderAttachments() {
+                if (!attachmentsList) return;
+                if (!attachments.length) {
+                    attachmentsList.innerHTML = '';
+                    return;
+                }
+
+                const cards = attachments.map((shot, index) => {
+                    const safeName = shot.name || `Screenshot ${index + 1}`;
+                    const meta = `${shot.type || 'image'} · ${formatBytes(shot.size)}`;
+
+                    return `
+                        <div class="screenshot-card">
+                            <img src="${shot.dataUrl}" alt="${safeName}" class="screenshot-thumb">
+                            <div class="screenshot-info">
+                                <div class="screenshot-name">${safeName}</div>
+                                <div class="screenshot-meta">${meta}</div>
+                                <button type="button" class="screenshot-remove" data-index="${index}">Remove</button>
+                            </div>
+                        </div>
+                    `;
+                }).join('');
+
+                attachmentsList.innerHTML = cards;
+            }
+
+            function readFileAsDataURL(file) {
+                return new Promise((resolve, reject) => {
+                    const reader = new FileReader();
+                    reader.onload = () => resolve(reader.result);
+                    reader.onerror = () => reject(new Error('Failed to read screenshot.'));
+                    reader.readAsDataURL(file);
+                });
+            }
+
+            async function addAttachmentFromFile(file) {
+                if (!file) return;
+
+                if (!file.type || !file.type.startsWith('image/')) {
+                    showAttachmentFeedback('Only image screenshots are supported.');
+                    return;
+                }
+
+                if (attachments.length >= MAX_SCREENSHOTS) {
+                    showAttachmentFeedback(`You can attach up to ${MAX_SCREENSHOTS} screenshots.`);
+                    return;
+                }
+
+                if (file.size > MAX_SCREENSHOT_BYTES) {
+                    const maxMb = (MAX_SCREENSHOT_BYTES / (1024 * 1024)).toFixed(1);
+                    showAttachmentFeedback(`"${file.name}" is too large. Maximum size is ${maxMb}MB.`);
+                    return;
+                }
+
+                try {
+                    const dataUrl = await readFileAsDataURL(file);
+                    attachments.push({
+                        name: file.name || `screenshot-${attachments.length + 1}.png`,
+                        type: file.type || 'image/png',
+                        size: file.size,
+                        dataUrl
+                    });
+                    clearAttachmentFeedback();
+                    renderAttachments();
+                } catch (error) {
+                    showAttachmentFeedback(error.message);
+                }
+            }
+
+            async function handleFileSelection(fileList) {
+                if (!fileList || !fileList.length) {
+                    return;
+                }
+
+                for (const file of Array.from(fileList)) {
+                    await addAttachmentFromFile(file);
+                    if (attachments.length >= MAX_SCREENSHOTS) {
+                        break;
+                    }
+                }
+            }
+
+            if (screenshotInput) {
+                screenshotInput.addEventListener('change', async (event) => {
+                    await handleFileSelection(event.target.files);
+                    event.target.value = '';
+                });
+            }
+
+            if (attachmentsList) {
+                attachmentsList.addEventListener('click', (event) => {
+                    const target = event.target;
+                    if (target && target.matches('.screenshot-remove')) {
+                        const index = Number(target.getAttribute('data-index'));
+                        if (!Number.isNaN(index)) {
+                            attachments.splice(index, 1);
+                            renderAttachments();
+                            if (!attachments.length) {
+                                clearAttachmentFeedback();
+                            }
+                        }
+                    }
+                });
+            }
+
+            if (notesInput) {
+                notesInput.addEventListener('paste', async (event) => {
+                    if (!event.clipboardData || !event.clipboardData.items) {
+                        return;
+                    }
+
+                    const imageItems = Array.from(event.clipboardData.items).filter(item => item.type && item.type.startsWith('image/'));
+                    if (!imageItems.length) {
+                        return;
+                    }
+
+                    event.preventDefault();
+
+                    for (const item of imageItems) {
+                        const file = item.getAsFile();
+                        if (file) {
+                            await addAttachmentFromFile(file);
+                            if (attachments.length >= MAX_SCREENSHOTS) {
+                                break;
+                            }
+                        }
+                    }
+                });
+            }
+
+            form.addEventListener('submit', async (event) => {
+                event.preventDefault();
+
+                const urlInput = document.getElementById('failure-url');
+                const payload = { url: urlInput.value.trim() };
+
+                if (!payload.url) {
+                    statusEl.textContent = 'Please provide a valid URL.';
+                    statusEl.className = 'report-status error';
+                    statusEl.style.display = 'block';
+                    return;
+                }
+
+                if (notesInput) {
+                    const notesValue = notesInput.value.trim();
+                    if (notesValue) {
+                        payload.notes = notesValue;
+                    }
+                }
+
+                if (attachments.length) {
+                    payload.screenshots = attachments.map(({ name, type, size, dataUrl }) => ({
+                        name,
+                        type,
+                        size,
+                        dataUrl
+                    }));
+                }
+
+                statusEl.textContent = 'Submitting report...';
+                statusEl.className = 'report-status pending';
+                statusEl.style.display = 'block';
+
+                try {
+                    const response = await fetch('/report-parse-issue', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify(payload)
+                    });
+
+                    const data = await response.json();
+
+                    if (!response.ok || !data.success) {
+                        throw new Error(data.error || 'Request failed');
+                    }
+
+                    form.reset();
+                    attachments.length = 0;
+                    renderAttachments();
+                    clearAttachmentFeedback();
+
+                    const issue = data.issue || {};
+                    const analysis = data.analysis || {};
+                    const extraction = analysis.extraction || {};
+                    const config = analysis.config || {};
+                    const codexTask = data.codexTask || null;
+                    const attachmentMeta = Array.isArray(data.attachments) ? data.attachments : [];
+                    const screenshotComment = data.screenshotComment || null;
+
+                    let summary = extraction.success ?
+                        'Local extraction succeeded for comparison.' :
+                        'Local extraction failed to reproduce the article.';
+
+                    if (!extraction.success && extraction.error) {
+                        summary += ` (${extraction.error})`;
+                    }
+
+                    if (config.available === true) {
+                        summary += ' Config found for this site.';
+                    } else if (config.available === false) {
+                        summary += ' No FiveFilters config detected.';
+                    }
+
+                    const link = issue.url ?
+                        `<a href="${issue.url}" target="_blank" rel="noopener noreferrer">GitHub issue #${issue.number}</a>` :
+                        'GitHub issue';
+
+                    let codexSummary = '';
+                    if (codexTask && typeof codexTask === 'object') {
+                        if (codexTask.success) {
+                            const jobId = codexTask.jobId ? ` (job ${codexTask.jobId})` : '';
+                            codexSummary = ` Codex agent triggered${jobId}.`;
+                        } else if (codexTask.error) {
+                            codexSummary = ` Codex automation failed: ${codexTask.error}.`;
+                        } else {
+                            codexSummary = ' Codex automation status unknown.';
+                        }
+                    } else if (codexTask === null) {
+                        codexSummary = ' Codex automation not configured on this service.';
+                    }
+
+                    let attachmentsSummary = '';
+                    if (attachmentMeta.length) {
+                        const count = attachmentMeta.length;
+                        attachmentsSummary = ` ${count} screenshot${count > 1 ? 's' : ''} attached for triage.`;
+                    }
+
+                    let screenshotCommentSummary = '';
+                    if (screenshotComment) {
+                        if (screenshotComment.error) {
+                            screenshotCommentSummary = ` Screenshot upload error: ${screenshotComment.error}.`;
+                        } else if (screenshotComment.url) {
+                            screenshotCommentSummary = ` <a href="${screenshotComment.url}" target="_blank" rel="noopener noreferrer">View uploaded screenshots</a>.`;
+                        }
+                    }
+
+                    statusEl.innerHTML = `Created ${link}. ${summary}${codexSummary}${attachmentsSummary}${screenshotCommentSummary}`;
+                    statusEl.className = 'report-status success';
+                    statusEl.style.display = 'block';
+                } catch (error) {
+                    statusEl.textContent = `Failed to submit report: ${error.message}`;
+                    statusEl.className = 'report-status error';
+                    statusEl.style.display = 'block';
+                }
+            });
+        }
+
         // Initialize
         generateBookmarklet();
         checkStatus();
-        
+        initFailureReportForm();
+
         // Refresh status every 30 seconds
         setInterval(checkStatus, 30000);
     </script>

--- a/src/codexAgentClient.js
+++ b/src/codexAgentClient.js
@@ -1,0 +1,93 @@
+const axios = require('axios');
+
+function sanitiseNotes(notes) {
+  if (!notes) return '';
+  if (typeof notes !== 'string') return '';
+  return notes.trim();
+}
+
+function buildPayload({ issueNumber, issueUrl, notes, analysis }) {
+  const payload = {
+    issue: {
+      number: issueNumber,
+      url: issueUrl
+    },
+    analysis: analysis || {}
+  };
+
+  const trimmedNotes = sanitiseNotes(notes);
+  if (trimmedNotes) {
+    payload.notes = trimmedNotes;
+  }
+
+  if (process.env.CODEX_AGENT_ID) {
+    payload.agentId = process.env.CODEX_AGENT_ID;
+  }
+
+  if (process.env.CODEX_AGENT_REPO || process.env.GITHUB_REPOSITORY) {
+    payload.repository = process.env.CODEX_AGENT_REPO || process.env.GITHUB_REPOSITORY;
+  }
+
+  return payload;
+}
+
+async function triggerCodexAgent({ issueNumber, issueUrl, notes, analysis }) {
+  const endpoint = process.env.CODEX_AGENT_API_URL;
+  const apiKey = process.env.CODEX_AGENT_API_KEY;
+
+  if (!endpoint) {
+    console.log('Codex agent endpoint not configured; skipping automation.');
+    return null;
+  }
+
+  const payload = buildPayload({ issueNumber, issueUrl, notes, analysis });
+  const headers = {
+    'Content-Type': 'application/json'
+  };
+
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  if (process.env.CODEX_AGENT_API_EXTRA_HEADERS) {
+    try {
+      const extraHeaders = JSON.parse(process.env.CODEX_AGENT_API_EXTRA_HEADERS);
+      Object.assign(headers, extraHeaders);
+    } catch (error) {
+      console.warn('Failed to parse CODEX_AGENT_API_EXTRA_HEADERS:', error.message);
+    }
+  }
+
+  try {
+    const response = await axios.post(endpoint, payload, {
+      headers,
+      timeout: Number(process.env.CODEX_AGENT_API_TIMEOUT_MS) || 20000
+    });
+
+    return {
+      success: true,
+      jobId: response.data?.jobId || response.data?.id || null,
+      raw: response.data
+    };
+  } catch (error) {
+    if (error.response) {
+      console.error('Codex agent trigger failed:', error.response.status, error.response.data);
+      return {
+        success: false,
+        status: error.response.status,
+        error: error.response.data?.message || error.response.statusText || 'Unknown API error'
+      };
+    }
+
+    console.error('Codex agent trigger failed:', error.message);
+    return {
+      success: false,
+      status: null,
+      error: error.message
+    };
+  }
+}
+
+module.exports = {
+  triggerCodexAgent
+};

--- a/src/failureReporter.js
+++ b/src/failureReporter.js
@@ -1,0 +1,418 @@
+const axios = require('axios');
+const { extractArticle } = require('./articleExtractor');
+const GitHubAuth = require('./githubAuth');
+const { triggerCodexAgent } = require('./codexAgentClient');
+
+class FailureReportError extends Error {
+  constructor(message, status = 500) {
+    super(message);
+    this.name = 'FailureReportError';
+    this.status = status;
+  }
+}
+
+function truncateText(text, limit) {
+  if (!text) return '';
+  if (text.length <= limit) return text;
+  return text.slice(0, limit - 3).trimEnd() + '...';
+}
+
+function collapseWhitespace(text) {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function formatBlock(text) {
+  return text
+    .split(/\r?\n/)
+    .map(line => `> ${line.trimEnd()}`)
+    .join('\n');
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+function sanitizeFilename(name) {
+  if (!name || typeof name !== 'string') {
+    return 'screenshot.png';
+  }
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return 'screenshot.png';
+  }
+  const cleaned = trimmed.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return cleaned.slice(0, 80) || 'screenshot.png';
+}
+
+function extractBase64Payload(source) {
+  if (!source || typeof source !== 'string') {
+    throw new FailureReportError('Screenshot data is missing', 400);
+  }
+
+  const trimmed = source.trim();
+  const dataUrlMatch = trimmed.match(/^data:([^;,]+);base64,(.+)$/);
+
+  if (dataUrlMatch) {
+    return {
+      mime: dataUrlMatch[1],
+      base64: dataUrlMatch[2].replace(/\s+/g, '')
+    };
+  }
+
+  return {
+    mime: '',
+    base64: trimmed.replace(/\s+/g, '')
+  };
+}
+
+function normalizeScreenshots(rawScreenshots) {
+  if (!Array.isArray(rawScreenshots) || !rawScreenshots.length) {
+    return {
+      screenshots: [],
+      limits: {
+        maxCount: parsePositiveInt(process.env.PARSE_REPORT_MAX_SCREENSHOTS, 3),
+        maxBytes: parsePositiveInt(process.env.PARSE_REPORT_MAX_SCREENSHOT_BYTES, 2 * 1024 * 1024)
+      }
+    };
+  }
+
+  const maxCount = parsePositiveInt(process.env.PARSE_REPORT_MAX_SCREENSHOTS, 3);
+  const maxBytes = parsePositiveInt(process.env.PARSE_REPORT_MAX_SCREENSHOT_BYTES, 2 * 1024 * 1024);
+  const screenshots = [];
+
+  for (const entry of rawScreenshots) {
+    if (screenshots.length >= maxCount) {
+      break;
+    }
+
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+
+    let payload;
+    try {
+      payload = extractBase64Payload(entry.dataUrl || entry.data || '');
+    } catch (error) {
+      throw new FailureReportError(error.message, 400);
+    }
+
+    let buffer;
+    try {
+      buffer = Buffer.from(payload.base64, 'base64');
+    } catch (error) {
+      throw new FailureReportError('Screenshot payload is not valid base64 data', 400);
+    }
+
+    if (!buffer.length) {
+      throw new FailureReportError('Screenshot payload is empty', 400);
+    }
+
+    if (buffer.length > maxBytes) {
+      const maxMb = (maxBytes / (1024 * 1024)).toFixed(1);
+      const safeName = sanitizeFilename(entry.name);
+      throw new FailureReportError(`Screenshot "${safeName}" exceeds the ${maxMb}MB limit`, 400);
+    }
+
+    const safeName = sanitizeFilename(entry.name);
+    const mimeType = entry.type && typeof entry.type === 'string' && entry.type.startsWith('image/')
+      ? entry.type
+      : (payload.mime && payload.mime.startsWith('image/') ? payload.mime : 'image/png');
+
+    screenshots.push({
+      name: safeName,
+      type: mimeType,
+      size: buffer.length,
+      base64: payload.base64
+    });
+  }
+
+  return {
+    screenshots,
+    limits: {
+      maxCount,
+      maxBytes
+    }
+  };
+}
+
+function buildIssueTitle(parsedUrl) {
+  const segments = parsedUrl.pathname.split('/').filter(Boolean);
+  const lastSegment = segments.length ? segments[segments.length - 1] : '';
+  const slug = lastSegment ? `/${truncateText(lastSegment, 40)}` : '';
+  let title = `Parse failure: ${parsedUrl.hostname}${slug}`;
+  if (title.length > 120) {
+    title = truncateText(title, 120);
+  }
+  return title;
+}
+
+function buildScreenshotSection(screenshots) {
+  if (!Array.isArray(screenshots) || !screenshots.length) {
+    return '_No screenshots supplied._';
+  }
+
+  const lines = screenshots.map((shot, index) => {
+    const sizeKb = Math.max(1, Math.round(shot.size / 1024));
+    const label = shot.name || `Screenshot ${index + 1}`;
+    return `- ${label} (${shot.type || 'image'}, ~${sizeKb} KB)`;
+  });
+
+  lines.push('_Binary data is included in an automated comment below._');
+  return lines.join('\n');
+}
+
+function buildIssueBody({ url, notes, analysis, screenshots }) {
+  const notesSection = notes ? formatBlock(notes) : '_None provided._';
+
+  const lines = [
+    `- Analysis timestamp: ${analysis.timestamp}`,
+    `- Config lookup: ${analysis.config.available ? 'Found' : 'Missing'}${analysis.config.detail ? ` (${analysis.config.detail})` : ''}`,
+    `- Extraction attempt: ${analysis.extraction.success ? 'Succeeded' : 'Failed'}`
+  ];
+
+  if (analysis.extraction.success) {
+    lines.push(`- Extracted title: ${analysis.extraction.title || 'n/a'}`);
+    lines.push(`- Extracted length: ${analysis.extraction.contentLength || 0} characters`);
+  } else if (analysis.extraction.error) {
+    lines.push(`- Error: ${analysis.extraction.error}`);
+  }
+
+  let body = `## Reported URL\n${url}\n\n## Reporter Notes\n${notesSection}\n\n## Automated Analysis\n${lines.join('\n')}`;
+
+  if (analysis.extraction.success && analysis.extraction.textPreview) {
+    body += `\n\n#### Text sample\n${formatBlock(analysis.extraction.textPreview)}`;
+  }
+
+  body += `\n\n## Screenshots\n${buildScreenshotSection(screenshots)}`;
+
+  return body;
+}
+
+function buildScreenshotComment(screenshots) {
+  if (!Array.isArray(screenshots) || !screenshots.length) {
+    return '';
+  }
+
+  const parts = [
+    '## User Screenshots',
+    '_Uploaded automatically from the parse failure form._'
+  ];
+
+  screenshots.forEach((shot, index) => {
+    const label = shot.name || `Screenshot ${index + 1}`;
+    const sizeKb = Math.max(1, Math.round(shot.size / 1024));
+    const mimeType = shot.type || 'image/png';
+
+    parts.push('');
+    parts.push('<details>');
+    parts.push(`<summary>${label} (${mimeType}, ~${sizeKb.toLocaleString()} KB)</summary>`);
+    parts.push('');
+    parts.push('```base64');
+    parts.push(`data:${mimeType};base64,${shot.base64}`);
+    parts.push('```');
+    parts.push('');
+    parts.push('</details>');
+  });
+
+  parts.push('');
+  parts.push('> Tip: copy the base64 block into a file and decode it with `base64 --decode` to recreate the image.');
+
+  return parts.join('\n');
+}
+
+async function analyzeUrl(url, configFetcher) {
+  const parsedUrl = new URL(url);
+  const analysis = {
+    url,
+    hostname: parsedUrl.hostname,
+    timestamp: new Date().toISOString(),
+    config: {
+      available: false,
+      detail: ''
+    },
+    extraction: {
+      success: false,
+      title: '',
+      contentLength: 0,
+      textPreview: '',
+      error: ''
+    }
+  };
+
+  if (configFetcher) {
+    try {
+      const config = await configFetcher.getConfigForSite(parsedUrl.hostname);
+      if (config) {
+        analysis.config.available = true;
+        analysis.config.detail = `title rules: ${config.title?.length || 0}, body rules: ${config.body?.length || 0}, strip rules: ${config.strip?.length || 0}, preferJsonLd: ${config.preferJsonLd ? 'yes' : 'no'}`;
+      } else {
+        analysis.config.detail = 'No FiveFilters config found.';
+      }
+    } catch (error) {
+      analysis.config.detail = `Config lookup failed: ${error.message}`;
+    }
+  } else {
+    analysis.config.detail = 'Config fetcher unavailable.';
+  }
+
+  try {
+    const article = await extractArticle(url);
+    analysis.extraction.success = true;
+    analysis.extraction.title = article.title || '';
+    analysis.extraction.contentLength = article.content ? article.content.length : 0;
+
+    if (article.textContent) {
+      const preview = truncateText(collapseWhitespace(article.textContent), 400);
+      analysis.extraction.textPreview = preview;
+    }
+  } catch (error) {
+    analysis.extraction.error = error.message;
+  }
+
+  return analysis;
+}
+
+async function createIssue({ title, body, githubAuth }) {
+  if (!process.env.GITHUB_REPOSITORY) {
+    throw new FailureReportError('GITHUB_REPOSITORY is not configured', 500);
+  }
+
+  let headers;
+  try {
+    headers = await githubAuth.getAuthHeaders();
+  } catch (error) {
+    throw new FailureReportError(error.message, 500);
+  }
+
+  try {
+    const response = await axios.post(
+      `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/issues`,
+      { title, body },
+      { headers }
+    );
+    return response.data;
+  } catch (error) {
+    if (error.response) {
+      const status = error.response.status;
+      const detail = error.response.data && error.response.data.message ? error.response.data.message : `status ${status}`;
+      throw new FailureReportError(`GitHub issue creation failed: ${detail}`, status >= 400 && status < 500 ? status : 502);
+    }
+    throw new FailureReportError(`GitHub issue creation failed: ${error.message}`, 502);
+  }
+}
+
+async function postScreenshotComment({ githubAuth, issueNumber, screenshots }) {
+  if (!Array.isArray(screenshots) || !screenshots.length) {
+    return null;
+  }
+
+  if (!process.env.GITHUB_REPOSITORY) {
+    throw new FailureReportError('GITHUB_REPOSITORY is not configured', 500);
+  }
+
+  let headers;
+  try {
+    headers = await githubAuth.getAuthHeaders();
+  } catch (error) {
+    throw new FailureReportError(error.message, 500);
+  }
+
+  try {
+    const response = await axios.post(
+      `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/issues/${issueNumber}/comments`,
+      { body: buildScreenshotComment(screenshots) },
+      { headers }
+    );
+
+    return {
+      id: response.data?.id || null,
+      url: response.data?.html_url || null
+    };
+  } catch (error) {
+    if (error.response) {
+      const status = error.response.status;
+      const detail = error.response.data && error.response.data.message ? error.response.data.message : `status ${status}`;
+      throw new FailureReportError(`Failed to attach screenshots: ${detail}`, status >= 400 && status < 500 ? status : 502);
+    }
+    throw new FailureReportError(`Failed to attach screenshots: ${error.message}`, 502);
+  }
+}
+
+async function reportParsingIssue({ url, notes = '', screenshots = [], configFetcher }) {
+  if (!url || typeof url !== 'string') {
+    throw new FailureReportError('URL is required', 400);
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new FailureReportError('Invalid URL provided', 400);
+  }
+
+  const githubAuth = new GitHubAuth();
+  if (!githubAuth.authMethod || githubAuth.authMethod === 'ssh-deploy-key') {
+    throw new FailureReportError('GitHub token or app credentials are required for issue creation', 500);
+  }
+
+  const trimmedNotes = typeof notes === 'string' ? notes.trim() : '';
+  const { screenshots: normalizedScreenshots, limits } = normalizeScreenshots(Array.isArray(screenshots) ? screenshots : []);
+
+  const analysis = await analyzeUrl(url, configFetcher);
+  const attachmentSummaries = normalizedScreenshots.map(shot => ({
+    name: shot.name,
+    type: shot.type,
+    size: shot.size
+  }));
+
+  if (attachmentSummaries.length) {
+    analysis.attachments = attachmentSummaries;
+  }
+
+  const issueTitle = buildIssueTitle(parsedUrl);
+  const issueBody = buildIssueBody({ url, notes: trimmedNotes, analysis, screenshots: normalizedScreenshots });
+  const issue = await createIssue({ title: issueTitle, body: issueBody, githubAuth });
+
+  const codexTask = await triggerCodexAgent({
+    issueNumber: issue.number,
+    issueUrl: issue.html_url,
+    notes: trimmedNotes,
+    analysis
+  });
+
+  let screenshotComment = null;
+  if (normalizedScreenshots.length) {
+    try {
+      screenshotComment = await postScreenshotComment({
+        githubAuth,
+        issueNumber: issue.number,
+        screenshots: normalizedScreenshots
+      });
+    } catch (error) {
+      console.error('Failed to upload screenshots:', error);
+      screenshotComment = {
+        error: error.message,
+        status: error.status || null
+      };
+    }
+  }
+
+  return {
+    issueNumber: issue.number,
+    issueUrl: issue.html_url,
+    analysis,
+    codexTask,
+    attachments: attachmentSummaries,
+    screenshotComment,
+    attachmentLimits: limits
+  };
+}
+
+module.exports = {
+  reportParsingIssue,
+  FailureReportError
+};


### PR DESCRIPTION
## Summary
- add a customer-facing form to report parse failures, with optional notes and screenshots
- create server-side reporter that files GitHub issues and (if present) uploads screenshots as a comment
- document available gh and doctl command line tools for agents

## Testing
- npm test *(fails: node_modules not installed in the sandbox; missing dotenv)*